### PR TITLE
Add selective document processing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Sistema automatizado para recopilar, procesar y organizar documentos personales 
 # Pipeline completo
 python process_documents.py [--year 2025]
 
+# Solo procesar tweets y PDFs
+python process_documents.py tweets pdfs
+
 # Solo convertir archivos .md a HTML
 python md_to_html.py
 ```
@@ -95,7 +98,7 @@ export INSTAPAPER_PASSWORD="tu_contraseña"
 
 | Script | Función |
 |--------|---------|
-| `process_documents.py` | Script principal - Pipeline completo |
+| `process_documents.py` | Script principal - Pipeline completo o parcial |
 | `md_to_html.py` | Convierte archivos .md a HTML con márgenes |
 | `pipeline_manager.py` | Coordinación de procesadores |
 | `instapaper_processor.py` | Descarga y procesa artículos web |

--- a/tests/test_process_documents_cli.py
+++ b/tests/test_process_documents_cli.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Tests for process_documents CLI selection."""
+import sys
+import process_documents
+
+
+def run_main(monkeypatch, tmp_path, args):
+    calls = []
+
+    class DummyProcessor:
+        def __init__(self, config):
+            pass
+
+        def process_all(self):
+            calls.append("all")
+            return True
+
+        def process_podcasts(self):
+            calls.append("podcasts")
+            return []
+
+        def process_tweets(self):
+            calls.append("tweets")
+            return []
+
+        def process_instapaper_posts(self):
+            calls.append("posts")
+            return []
+
+        def process_pdfs(self):
+            calls.append("pdfs")
+            return []
+
+        def register_all_files(self):
+            calls.append("register")
+
+    monkeypatch.setattr(process_documents, "DocumentProcessor", DummyProcessor)
+    monkeypatch.setattr(process_documents.cfg, "BASE_DIR", tmp_path)
+    monkeypatch.setenv("DOCPIPE_YEAR", "2025")
+
+    monkeypatch.setattr(sys, "argv", ["process_documents.py", *args])
+    process_documents.main()
+    return calls
+
+
+def test_default_runs_all(monkeypatch, tmp_path):
+    calls = run_main(monkeypatch, tmp_path, [])
+    assert calls == ["all"]
+
+
+def test_selective_processing(monkeypatch, tmp_path):
+    calls = run_main(monkeypatch, tmp_path, ["tweets", "pdfs"])
+    assert calls == ["tweets", "pdfs", "register"]
+


### PR DESCRIPTION
## Summary
- Allow running `process_documents.py` on specific targets like `tweets`, `pdfs`, `podcasts` or `posts`
- Document new selective usage in README
- Cover CLI behavior with tests

## Testing
- `pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests markdown` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a572162e0483228d8675c9c5b594a9